### PR TITLE
Add read-attributes and raw-read-attributes

### DIFF
--- a/src/test/clojure/clojure/java/test_jmx.clj
+++ b/src/test/clojure/clojure/java/test_jmx.clj
@@ -60,15 +60,12 @@
              (are [a b] (= a b)
                   false (jmx/raw-read mem :Verbose))
              (are [type attr] (instance? type attr)
-                  Number (jmx/raw-read mem :ObjectPendingFinalizationCount)))))
-
-(deftest raw-reading-multiple-attributes
-  (let [mem "java.lang:type=Memory"]
-    (testing "simple scalar attributes"
+                  Number (jmx/raw-read mem :ObjectPendingFinalizationCount)))
+    (testing "reading multiple attributes"
              (are [a b] (= a b)
-                  false ((jmx/raw-read-attributes mem [:Verbose]) :Verbose))
+                  false ((jmx/raw-read mem [:Verbose]) :Verbose))
              (are [type attr] (instance? type attr)
-                  Number ((jmx/raw-read-attributes mem [:ObjectPendingFinalizationCount]) :ObjectPendingFinalizationCount)))))
+                  Number ((jmx/raw-read mem [:ObjectPendingFinalizationCount]) :ObjectPendingFinalizationCount)))))
 
 (deftest reading-attributes
   (testing "simple scalar attributes"
@@ -83,13 +80,13 @@
 (deftest reading-multiple-attributes
   (testing "simple scalar attributes"
            (are [type attr] (instance? type attr)
-                Number ((jmx/read-attributes "java.lang:type=Memory" [:ObjectPendingFinalizationCount]) :ObjectPendingFinalizationCount)))
+                Number ((jmx/read "java.lang:type=Memory" [:ObjectPendingFinalizationCount]) :ObjectPendingFinalizationCount)))
   (testing "composite attributes"
            (are [ks attr] (=set ks (keys attr))
-                [:used :max :init :committed] 
-                ((jmx/read-attributes "java.lang:type=Memory" [:HeapMemoryUsage :NonHeapMemoryUsage]) :HeapMemoryUsage)))
+                [:used :max :init :committed]
+                ((jmx/read "java.lang:type=Memory" [:HeapMemoryUsage :NonHeapMemoryUsage]) :HeapMemoryUsage)))
   (testing "tabular attributes"
-           (is (map? ((jmx/read-attributes "java.lang:type=Runtime" [:SystemProperties]) :SystemProperties)))))
+           (is (map? ((jmx/read "java.lang:type=Runtime" [:SystemProperties]) :SystemProperties)))))
 
 (deftest writing-attributes
   (let [mem "java.lang:type=Memory"]


### PR DESCRIPTION
This pull request adds two functions to allow you to read multiple attributes from an MBean with a single JMX call.  This pull request includes tests for both functions.

You may want to implement read and raw-read using the new functions, but I have left them alone for now.
