### PR TITLE
Explicitly create an Object array for invoke parameters.

### DIFF
--- a/src/main/clojure/clojure/java/jmx.clj
+++ b/src/main/clojure/clojure/java/jmx.clj
@@ -265,7 +265,7 @@
   [n op & args]
   (if ( seq args)
     (.invoke *connection* (as-object-name n) (name op)
-             (into-array args)
+             (into-array Object args)
              (into-array String  (op-param-types n op)))
     (.invoke *connection* (as-object-name n) (name op)
              nil nil)))


### PR DESCRIPTION
into-array fails when you try and use mutliple parameters of different types. We should just explicitly make it an Object array since thats what the invoke method signature asks for anyway.
