### PR TITLE
.getAttribute on Bean does not actually yield an Attribute, causing ClassCastException

### DIFF
--- a/src/main/clojure/clojure/java/jmx.clj
+++ b/src/main/clojure/clojure/java/jmx.clj
@@ -146,7 +146,10 @@
    (into {} (zipmap (keys m) (map objects->data (vals m)))))
 
   Object
-  (objects->data [obj] obj))
+  (objects->data [obj] obj)
+
+  javax.management.Attribute
+  (objects->data [attr] (.getValue attr)))
 
 (def ^{:private true} guess-attribute-map
      {"java.lang.Integer" "int"
@@ -315,7 +318,7 @@
                             nil                                                 ; operations
                             nil))
   (getAttribute [_ attr]
-                (@state-ref (keyword attr)))
+                (Attribute. attr (@state-ref (keyword attr))))
   (getAttributes [_ attrs]
                  (let [result (AttributeList.)]
                    (doseq [attr attrs]

--- a/src/test/clojure/clojure/java/test_jmx.clj
+++ b/src/test/clojure/clojure/java/test_jmx.clj
@@ -12,7 +12,7 @@
 
 (ns clojure.java.test-jmx
   (:import javax.management.openmbean.CompositeDataSupport
-           [javax.management MBeanAttributeInfo AttributeList]
+           [javax.management MBeanAttributeInfo Attribute AttributeList]
            [java.util.logging LogManager Logger])
   (:use clojure.test)
   (:require [clojure.java [jmx :as jmx]]))
@@ -169,8 +169,9 @@
     (let [state (reftype {:a 1 :b 2})
           bean (jmx/create-bean state)]
       (testing (str "accessing values from a " (class state))
-               (are [result expr] (= result expr)
-                    1 (.getAttribute bean "a"))))))
+        (are [result expr] (= result expr)
+             "a" (.getName (.getAttribute bean "a"))
+             1 (.getValue (.getAttribute bean "a")))))))
 
 (deftest test-bean-info
   (let [state (ref {:a 1 :b 2})
@@ -185,7 +186,8 @@
         atts (.getAttributes bean (into-array ["r" "d"]))]
     (are [x y] (= x y)
          AttributeList (class atts)
-         [5 4] (seq atts))))
+         ["r" "d"] (map (memfn getName) (seq atts))
+         [5 4] (map (memfn getValue) (seq atts)))))
 
 (def primitive-int? (< (.compareTo (clojure-version) "1.3.0") 0))
 


### PR DESCRIPTION
When `create-bean` is used according to the documentation, that is, with a ref to a map whose keys are attribute names and whose values are simple attribute values (e.g., `(create-bean (ref {:success 0}))`), the resulting object has a `.getAttribute` method that yields the simple attribute value, rather than a javax.management.Attribute object.  This means that trying to add the attributes into an AttributeList causes a ClassCastException.

This commit attempts to fix this bug by wrapping the result of `.getAttribute` in a javax.management.Attribute.  However, then `jmx/read` returns the Attribute where you'd expect it to return the simple value, so I added an implementation of `objects->data` for Attributes.  The tests pass, and it works for my case, but I do not know whether that is the correct approach in general.
