### PR TITLE
Creating a bean with an empty map throws a ClassCastException

### DIFF
--- a/src/main/clojure/clojure/java/jmx.clj
+++ b/src/main/clojure/clojure/java/jmx.clj
@@ -174,7 +174,8 @@
 (defn- map->attribute-infos
   "Construct an MBeanAttributeInfo[] from a Clojure associative."
   [attr-map]
-  (into-array (map (fn [[attr-name value]] (build-attribute-info attr-name value))
+  (into-array MBeanAttributeInfo
+              (map (fn [[attr-name value]] (build-attribute-info attr-name value))
                    attr-map)))
 
 (defmacro with-connection


### PR DESCRIPTION
I noticed that creating a bean with an empty map doesn't work correctly. This one-liner fixes that by ensuring that 'map->attribute-infos' always returns a MBeanAttributeInfo[].

I know that you can't accept PR but you can go ahead and do this one-liner yourself.

Thx!

David
